### PR TITLE
[#59] Feat : 검사 관리 - 장비 CRUD 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 # application-* 파일을 Git에서 제외
 application-*.yml
+application-mytest.yml
 
 # 예외: application-example.yml 파일은 Git에 포함
 !application-example.yml

--- a/src/main/java/com/cloud/emr/Examination/Equipment/controller/EquipmentController.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/controller/EquipmentController.java
@@ -1,10 +1,10 @@
-package com.cloud.emr.Examination.Examination.controller;
+package com.cloud.emr.Examination.Equipment.controller;
 
-import com.cloud.emr.Examination.Examination.dto.ExaminationRegisterRequest;
-import com.cloud.emr.Examination.Examination.dto.ExaminationResponse;
-import com.cloud.emr.Examination.Examination.dto.ExaminationUpdateRequest;
-import com.cloud.emr.Examination.Examination.entity.ExaminationEntity;
-import com.cloud.emr.Examination.Examination.service.ExaminationService;
+import com.cloud.emr.Examination.Equipment.dto.EquipmentRegisterRequest;
+import com.cloud.emr.Examination.Equipment.dto.EquipmentResponse;
+import com.cloud.emr.Examination.Equipment.dto.EquipmentUpdateRequest;
+import com.cloud.emr.Examination.Equipment.entity.EquipmentEntity;
+import com.cloud.emr.Examination.Equipment.service.EquipmentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,19 +14,19 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/examination")
-public class ExaminationController {
+@RequestMapping("/api/equipment")
+public class EquipmentController {
 
-    private final ExaminationService examinationService;
+    private final EquipmentService equipmentService;
 
-    public ExaminationController(ExaminationService examinationService) {
-        this.examinationService = examinationService;
+    public EquipmentController(EquipmentService equipmentService) {
+        this.equipmentService = equipmentService;
     }
 
     @PostMapping("/register")
-    public ResponseEntity<Map<String, Object>> registerExamination(@RequestBody ExaminationRegisterRequest examinationRegisterRequest) {
+    public ResponseEntity<Map<String, Object>> registerEquipment(@RequestBody EquipmentRegisterRequest equipmentRegisterRequest) {
         try {
-            ExaminationEntity responseData = examinationService.registerExamination(examinationRegisterRequest);
+            EquipmentEntity responseData = equipmentService.registerEquipment(equipmentRegisterRequest);
 
             return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
                     "message", "등록 성공",
@@ -43,17 +43,17 @@ public class ExaminationController {
 
 
 
-    @GetMapping("/read/{examinationId}")
-    public ResponseEntity<Map<String, Object>> viewExamination(@PathVariable Long examinationId) {
+    @GetMapping("/read/{equipmentId}")
+    public ResponseEntity<Map<String, Object>> viewEquipment(@PathVariable Long equipmentId) {
         try {
-            ExaminationResponse examinationResponse = examinationService.readExamination(examinationId);
-            if (examinationResponse == null) {
+            EquipmentResponse equipmentResponse = equipmentService.readEquipment(equipmentId);
+            if (equipmentResponse == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "검사 정보를 찾을 수 없습니다."));
             }
 
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "message", "조회 성공",
-                    "data", examinationResponse
+                    "data", equipmentResponse
             ));
 
         } catch (Exception e) {
@@ -65,13 +65,13 @@ public class ExaminationController {
         }
     }
 
-    @GetMapping("/read/{equipmentID}")
-    public ResponseEntity<Map<String, Object>> getExaminationByEquipmentId(@PathVariable Long equipmentID) {
+    @GetMapping("/read/{equipmentName}")
+    public ResponseEntity<Map<String, Object>> getEquipmentByEquipmentName(@PathVariable String equipmentName) {
         try {
-            List<ExaminationResponse> examinationResponses = examinationService.readExaminationByEuipmentId(equipmentID);
+            List<EquipmentResponse> equipmentResponses = equipmentService.readEquipmentByEquipmentName(equipmentName);
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "message", "부분 조회 성공",
-                    "data", examinationResponses
+                    "data", equipmentResponses
             ));
         } catch (Exception e) {
 
@@ -84,12 +84,12 @@ public class ExaminationController {
 
     // 3. 장애인 정보 전체 조회
     @GetMapping("/read/all")
-    public ResponseEntity<Map<String, Object>> getAllExaminationInfo() {
+    public ResponseEntity<Map<String, Object>> getAllEquipmentInfo() {
         try {
-            List<ExaminationResponse> examinationResponses = examinationService.readAllExamination();
+            List<EquipmentResponse> equipmentResponses = equipmentService.readAllEquipment();
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "message", "전체 조회 성공",
-                    "data", examinationResponses
+                    "data", equipmentResponses
             ));
         } catch (Exception e) {
 
@@ -101,13 +101,13 @@ public class ExaminationController {
     }
 
     // 4. 장애인 정보 수정
-    @PostMapping("/update/{examinationId}")
-    public ResponseEntity<Map<String, Object>> updateExamination(
-            @PathVariable Long examinationId,
-            @RequestBody ExaminationUpdateRequest examinationUpdateRequest) {
+    @PostMapping("/update/{equipmentId}")
+    public ResponseEntity<Map<String, Object>> updateEquipment(
+            @PathVariable Long equipmentId,
+            @RequestBody EquipmentUpdateRequest equipmentUpdateRequest) {
 
         try {
-            ExaminationEntity updatedData = examinationService.updateExamination(examinationId, examinationUpdateRequest);
+            EquipmentEntity updatedData = equipmentService.updateEquipment(equipmentId, equipmentUpdateRequest);
 
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "message", "수정 성공",
@@ -123,15 +123,15 @@ public class ExaminationController {
 
 
     // 5. 장애인 정보 삭제
-    @PostMapping("/delete/{examinationId}")
-    public ResponseEntity<Map<String, Object>> deleteExamination(@PathVariable Long examinationId) {
+    @PostMapping("/delete/{equipmentId}")
+    public ResponseEntity<Map<String, Object>> deleteEquipment(@PathVariable Long equipmentId) {
         try {
 
-            ExaminationResponse deletedExamination = examinationService.deleteExamination(examinationId);
+            EquipmentResponse deletedEquipment = equipmentService.deleteEquipment(equipmentId);
 
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "message", "삭제 성공",
-                    "deletedExamination", deletedExamination
+                    "deletedEquipment", deletedEquipment
             ));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of(

--- a/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentRegisterRequest.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentRegisterRequest.java
@@ -1,4 +1,40 @@
 package com.cloud.emr.Examination.Equipment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class EquipmentRegisterRequest {
+
+    @Column(nullable = false)
+    @NotBlank(message = "필수 값입니다.")
+    private String equipmentName;
+
+    @Column(nullable = false)
+    @NotBlank(message = "필수 값입니다.")
+    private String equipmentProductNumber;
+
+    @Column(nullable = false)
+    @NotBlank(message = "필수 값입니다.")
+    private String equipmentManufacturer;
+
+    @Column(nullable = false)
+    @NotBlank(message = "필수 값입니다.")
+    private String equipmentLocation;
+
+    @Column(nullable = false)
+    @NotBlank(message = "필수 값입니다.")
+    private String equipmentState;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date equipmentSchedule;
+
 }

--- a/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentResponse.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentResponse.java
@@ -1,4 +1,30 @@
 package com.cloud.emr.Examination.Equipment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class EquipmentResponse {
+
+    private Long equipmentId;
+
+    private String equipmentName;
+
+    private String equipmentProductNumber;
+
+    private String equipmentManufacturer;
+
+    private String equipmentLocation;
+
+    private String equipmentState;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date equipmentSchedule;
+
 }

--- a/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentUpdateRequest.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/dto/EquipmentUpdateRequest.java
@@ -1,4 +1,28 @@
 package com.cloud.emr.Examination.Equipment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class EquipmentUpdateRequest {
+
+    private String equipmentName;
+
+    private String equipmentProductNumber;
+
+    private String equipmentManufacturer;
+
+    private String equipmentLocation;
+
+    private String equipmentState;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date equipmentSchedule;
+
 }

--- a/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentEntity.java
@@ -6,9 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,25 +25,24 @@ public class EquipmentEntity {
     @Column(name = "equipment_id", nullable = false)
     private Long equipmentId;
 
-    @Column(name = "equipment_name")
+    @Column(name = "equipment_name", nullable = false)
     private String equipmentName;
 
-    @Column(name = "equipment_product_number")
+    @Column(name = "equipment_product_number", nullable = false)
     private String equipmentProductNumber;
 
-    @Column(name = "equipment_manufacturer")
+    @Column(name = "equipment_manufacturer", nullable = false)
     private String equipmentManufacturer;
 
-    @Column(name = "equipment_location")
+    @Column(name = "equipment_location", nullable = false)
     private String equipmentLocation;
 
-    @Column(name = "equipment_state")
+    @Column(name = "equipment_state", nullable = false)
     private String equipmentState;
 
     @Column(name = "equipment_schedule")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date equipmentSchedule;
-
 
     // 이 아래는 그냥 다른 테이블에서 가져와서 화면에 띄울까?
 }

--- a/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentEntity.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
-@Entity(name = "Examination")
+@Entity(name = "Equipment")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentJournalEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/entity/EquipmentJournalEntity.java
@@ -18,7 +18,7 @@ import java.util.Date;
 
 import com.cloud.emr.Main.User.entity.UserEntity;
 
-@Entity(name = "ExaminationJournal")
+@Entity(name = "Equipment_Journal")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Equipment/repository/EquipmentRepository.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/repository/EquipmentRepository.java
@@ -1,12 +1,18 @@
 package com.cloud.emr.Examination.Equipment.repository;
 
 import com.cloud.emr.Examination.Equipment.entity.EquipmentEntity;
+import com.cloud.emr.Examination.Examination.entity.ExaminationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface EquipmentRepository extends JpaRepository<EquipmentEntity, Long> {
     EquipmentEntity findByEquipmentId(Long equipmentId);
+
+    Optional<EquipmentEntity> findByEquipmentIdOptional(Long equipmentId);
+
+    List<EquipmentEntity> findAllByEquipmentName(String equipmentName);
 }

--- a/src/main/java/com/cloud/emr/Examination/Equipment/service/EquipmentService.java
+++ b/src/main/java/com/cloud/emr/Examination/Equipment/service/EquipmentService.java
@@ -1,0 +1,137 @@
+package com.cloud.emr.Examination.Equipment.service;
+
+import com.cloud.emr.Examination.Equipment.dto.EquipmentRegisterRequest;
+import com.cloud.emr.Examination.Equipment.dto.EquipmentResponse;
+import com.cloud.emr.Examination.Equipment.dto.EquipmentUpdateRequest;
+import com.cloud.emr.Examination.Equipment.entity.EquipmentEntity;
+import com.cloud.emr.Examination.Equipment.repository.EquipmentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class EquipmentService {
+
+    private final EquipmentRepository equipmentRepository;
+
+    public EquipmentService(EquipmentRepository equipmentRepository) {
+        this.equipmentRepository = equipmentRepository;
+    }
+
+    public EquipmentEntity registerEquipment(EquipmentRegisterRequest equipmentRegisterRequest) {
+
+        EquipmentEntity equipmentEntity = EquipmentEntity.builder()
+                .equipmentName(equipmentRegisterRequest.getEquipmentName())
+                .equipmentProductNumber(equipmentRegisterRequest.getEquipmentProductNumber())
+                .equipmentManufacturer(equipmentRegisterRequest.getEquipmentManufacturer())
+                .equipmentLocation(equipmentRegisterRequest.getEquipmentLocation())
+                .equipmentState(equipmentRegisterRequest.getEquipmentState())
+                .equipmentSchedule(equipmentRegisterRequest.getEquipmentSchedule())
+                .build();
+
+        return equipmentRepository.save(equipmentEntity);
+    }
+
+    public EquipmentResponse readEquipment(Long equipmentId) {
+
+        EquipmentEntity equipmentEntity = equipmentRepository.findByEquipmentIdOptional(equipmentId)
+                .orElseThrow(() -> new RuntimeException("해당 장비 정보가 없습니다."));
+
+        return new EquipmentResponse(
+                equipmentEntity.getEquipmentId(),
+                equipmentEntity.getEquipmentName(),
+                equipmentEntity.getEquipmentProductNumber(),
+                equipmentEntity.getEquipmentManufacturer(),
+                equipmentEntity.getEquipmentLocation(),
+                equipmentEntity.getEquipmentState(),
+                equipmentEntity.getEquipmentSchedule()
+        );
+    }
+
+    public List<EquipmentResponse> readEquipmentByEquipmentName(String equipmentName) {
+
+        List<EquipmentEntity> equipmentEntities = equipmentRepository.findAllByEquipmentName(equipmentName);
+
+        return equipmentEntities.stream()
+                .map(equipmentEntity -> new EquipmentResponse(
+                        equipmentEntity.getEquipmentId(),
+                        equipmentEntity.getEquipmentName(),
+                        equipmentEntity.getEquipmentProductNumber(),
+                        equipmentEntity.getEquipmentManufacturer(),
+                        equipmentEntity.getEquipmentLocation(),
+                        equipmentEntity.getEquipmentState(),
+                        equipmentEntity.getEquipmentSchedule()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<EquipmentResponse> readAllEquipment() {
+
+        List<EquipmentEntity> equipmentEntities = equipmentRepository.findAll();
+
+        return equipmentEntities.stream()
+                .map(equipmentEntity -> new EquipmentResponse(
+                        equipmentEntity.getEquipmentId(),
+                        equipmentEntity.getEquipmentName(),
+                        equipmentEntity.getEquipmentProductNumber(),
+                        equipmentEntity.getEquipmentManufacturer(),
+                        equipmentEntity.getEquipmentLocation(),
+                        equipmentEntity.getEquipmentState(),
+                        equipmentEntity.getEquipmentSchedule()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public EquipmentEntity updateEquipment(Long equipmentId, EquipmentUpdateRequest equipmentUpdateRequest) {
+
+        EquipmentEntity equipmentEntity = equipmentRepository.findByEquipmentIdOptional(equipmentId)
+                .orElseThrow(() -> new RuntimeException("기존 해당 장비 정보가 없습니다."));
+
+        if(!equipmentUpdateRequest.getEquipmentName().isBlank()
+            || !equipmentUpdateRequest.getEquipmentProductNumber().isBlank()
+            || !equipmentUpdateRequest.getEquipmentManufacturer().isBlank()){
+            if(!equipmentUpdateRequest.getEquipmentName().isBlank()
+                && !equipmentUpdateRequest.getEquipmentProductNumber().isBlank()
+                && !equipmentUpdateRequest.getEquipmentManufacturer().isBlank()){
+                throw new RuntimeException("장비의 이름, 제품번호, 제조사를 모두 채우세요.");
+            }
+        }
+
+        EquipmentEntity updatedEntity = EquipmentEntity.builder()
+                .equipmentId(equipmentId)
+                .equipmentName(equipmentUpdateRequest.getEquipmentName() != null ? equipmentUpdateRequest.getEquipmentName() : equipmentEntity.getEquipmentName())
+                .equipmentProductNumber(equipmentUpdateRequest.getEquipmentProductNumber() != null ? equipmentUpdateRequest.getEquipmentProductNumber() : equipmentEntity.getEquipmentProductNumber())
+                .equipmentManufacturer(equipmentUpdateRequest.getEquipmentManufacturer() != null ? equipmentUpdateRequest.getEquipmentManufacturer() : equipmentEntity.getEquipmentManufacturer())
+                .equipmentLocation(equipmentUpdateRequest.getEquipmentLocation() != null ? equipmentUpdateRequest.getEquipmentLocation() : equipmentEntity.getEquipmentLocation())
+                .equipmentState(equipmentUpdateRequest.getEquipmentState() != null ? equipmentUpdateRequest.getEquipmentState() : equipmentEntity.getEquipmentState())
+                .equipmentSchedule(equipmentUpdateRequest.getEquipmentSchedule() != null ? equipmentUpdateRequest.getEquipmentSchedule() : equipmentEntity.getEquipmentSchedule())
+                .build();
+
+        return equipmentRepository.save(updatedEntity);
+    }
+
+    @Transactional
+    public EquipmentResponse deleteEquipment(Long equipmentId) {
+
+        EquipmentEntity equipmentEntity = equipmentRepository.findByEquipmentIdOptional(equipmentId)
+                .orElseThrow(() -> new RuntimeException("해당 장비 정보가 없습니다."));
+
+        EquipmentResponse deletedEquipment = new EquipmentResponse(
+                equipmentEntity.getEquipmentId(),
+                equipmentEntity.getEquipmentName(),
+                equipmentEntity.getEquipmentProductNumber(),
+                equipmentEntity.getEquipmentManufacturer(),
+                equipmentEntity.getEquipmentLocation(),
+                equipmentEntity.getEquipmentState(),
+                equipmentEntity.getEquipmentSchedule()
+        );
+
+        equipmentRepository.delete(equipmentEntity);
+
+        return deletedEquipment;
+    }
+}

--- a/src/main/java/com/cloud/emr/Examination/Examination/dto/ExaminationResponse.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/dto/ExaminationResponse.java
@@ -24,4 +24,5 @@ public class ExaminationResponse {
     private String examinationLocation;
 
     private String examinationPrice;
+
 }

--- a/src/main/java/com/cloud/emr/Examination/Examination/entity/BloodBankEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/entity/BloodBankEntity.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 import java.util.Date;
 
 import com.cloud.emr.Affair.Patient.entity.PatientEntity;
-import com.cloud.emr.Affair.Treatment.entity.TreatmentEntity;
+import com.cloud.emr.Treatment.Treatment.entity.TreatmentEntity;
 import com.cloud.emr.Main.User.entity.UserEntity;
 
-@Entity(name = "ExaminationSchedule")
+@Entity(name = "Blood_Bank")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationEntity.java
@@ -28,20 +28,20 @@ public class ExaminationEntity {
     @JoinColumn(name = "equipment_id", referencedColumnName = "equipment_id")
     private EquipmentEntity equipmentEntity;
 
-    @Column(name = "examination_name")
+    @Column(name = "examination_name", nullable = false)
     private String examinationName;
 
-    @Column(name = "examination_type")
+    @Column(name = "examination_type", nullable = false)
     private String examinationType;
 
     // 주의 사항, 금지 사항
     @Column(name = "examination_constraints")
     private String examinationConstraints;
 
-    @Column(name = "examination_location")
+    @Column(name = "examination_location", nullable = false)
     private String examinationLocation;
 
-    @Column(name = "examination_price")
+    @Column(name = "examination_price", nullable = false)
     private String examinationPrice;
 
     // 이 아래는 그냥 다른 테이블에서 가져와서 화면에 띄울까?

--- a/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationJournalEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationJournalEntity.java
@@ -17,13 +17,13 @@ import lombok.NoArgsConstructor;
 import java.util.Date;
 
 import com.cloud.emr.Affair.Patient.entity.PatientEntity;
-import com.cloud.emr.Affair.Treatment.entity.TreatmentEntity;
+import com.cloud.emr.Treatment.Treatment.entity.TreatmentEntity;
 import com.cloud.emr.Main.User.entity.UserEntity;
 // TODO: Make Doctor Entity
 // import com.cloud.emr.Main.User.entity.DoctorEntity;
 import com.cloud.emr.Examination.Equipment.entity.EquipmentEntity;
 
-@Entity(name = "ExaminationJournal")
+@Entity(name = "Examination_Journal")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationResultEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationResultEntity.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 import java.util.Date;
 
 import com.cloud.emr.Affair.Patient.entity.PatientEntity;
-import com.cloud.emr.Affair.Treatment.entity.TreatmentEntity;
+import com.cloud.emr.Treatment.Treatment.entity.TreatmentEntity;
 
-@Entity(name = "ExaminationResult")
+@Entity(name = "Examination_Result")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationScheduleEntity.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/entity/ExaminationScheduleEntity.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 import java.util.Date;
 
 import com.cloud.emr.Affair.Patient.entity.PatientEntity;
-import com.cloud.emr.Affair.Treatment.entity.TreatmentEntity;
+import com.cloud.emr.Treatment.Treatment.entity.TreatmentEntity;
 import com.cloud.emr.Main.User.entity.UserEntity;
 
-@Entity(name = "ExaminationSchedule")
+@Entity(name = "Examination_Schedule")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/cloud/emr/Examination/Examination/repository/ExaminationRepository.java
+++ b/src/main/java/com/cloud/emr/Examination/Examination/repository/ExaminationRepository.java
@@ -11,7 +11,10 @@ import java.util.Optional;
 @Repository
 public interface ExaminationRepository extends JpaRepository<ExaminationEntity, Long> {
 
-    Optional<ExaminationEntity> findByExaminationId(Long examinationId);
+    Optional<ExaminationEntity> findByExaminationIdOptional(Long examinationId);
+
+    ExaminationEntity findByExaminationId(Long examinationId);
+
     ExaminationEntity findByExaminationName(String examinationName);
 
     List<ExaminationEntity> findAllByEquipmentEntity(EquipmentEntity equipment);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: emr
   profiles:
-    active: mytest #dev 개발기 test 테스트 prod 운영기
+    active: test #dev 개발기 test 테스트 prod 운영기
   datasource:
     url: ${spring.datasource.url}
     username: ${spring.datasource.username}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: emr
   profiles:
-    active: test #dev 개발기 test 테스트 prod 운영기
+    active: mytest #dev 개발기 test 테스트 prod 운영기
   datasource:
     url: ${spring.datasource.url}
     username: ${spring.datasource.username}


### PR DESCRIPTION
##  작업 내용
- 장비 dto, repository, service, controller 생성
    - 장비 정보 관리 (Equipment) 
- 장비 파트 CRUD 부분 완성
- 내부 기능 구현
   - 장비 정보 등록
   - 장비 정보 조회
   - 장비 정보 장비 이름에 따라 조회
   - 장비 정보 전체 조회
   - 장비 정보 수정
   - 장비 정보 삭제

## ➕ 이슈 링크
- https://github.com/Eulji-Clou-D/cloud_emr_backend/issues/43
    - https://github.com/Eulji-Clou-D/cloud_emr_backend/issues/59

## 다음 예정 작업
- 나머지 엔터티에 대한 CRUD 작업
    - 검사 남은 엔터티들 작업 예정

## 체크리스트
- [x] 브랜치 이름은 `issue/대분류이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#소분류이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?